### PR TITLE
Switch to browserify

### DIFF
--- a/lib/button/index.js
+++ b/lib/button/index.js
@@ -1,3 +1,4 @@
+/** @jsx element */
 import element from 'virtual-element';
 
 /**

--- a/lib/checkbox/index.js
+++ b/lib/checkbox/index.js
@@ -1,3 +1,4 @@
+/** @jsx element */
 import element from 'virtual-element';
 
 /**
@@ -13,7 +14,7 @@ export default {
 
   render({ props }) {
     let { size, checked, onClick } = props;
-    
+
     let attrs = {
       class: 'matter-Checkbox',
       size: size || 'medium',

--- a/lib/code/index.js
+++ b/lib/code/index.js
@@ -1,3 +1,4 @@
+/** @jsx element */
 import element from 'virtual-element';
 import Highlight from 'syntax-highlighter';
 

--- a/lib/grid/index.js
+++ b/lib/grid/index.js
@@ -1,3 +1,4 @@
+/** @jsx element */
 import element from 'virtual-element';
 
 /**

--- a/lib/menu/index.js
+++ b/lib/menu/index.js
@@ -1,3 +1,4 @@
+/** @jsx element */
 import element from 'virtual-element';
 
 /**

--- a/lib/shape/index.js
+++ b/lib/shape/index.js
@@ -1,3 +1,4 @@
+/** @jsx element */
 import element from 'virtual-element';
 
 /**

--- a/lib/table/index.js
+++ b/lib/table/index.js
@@ -1,3 +1,4 @@
+/** @jsx element */
 import element from 'virtual-element';
 
 /**

--- a/lib/text-field/index.js
+++ b/lib/text-field/index.js
@@ -1,3 +1,4 @@
+/** @jsx element */
 import element from 'virtual-element';
 
 /**

--- a/package.json
+++ b/package.json
@@ -43,5 +43,10 @@
     "highlight-yaml": "0.0.1",
     "syntax-highlighter": "0.0.3",
     "virtual-element": "^1.2.0"
+  },
+  "browserify": {
+    "transform": [
+      "babelify"
+    ]
   }
 }


### PR DESCRIPTION
Wow, thanks for putting in the work to make this happen!  I have it building successfully with Browserify :smile:

I had to make a couple modifications, though, in order for Babel to parse it properly.  

The first thing is that Babel ignores everything in `node_modules` by default so as a user I would have to include this module manually by adding an ignore regex to my `.babelrc`.  However, I've added the following to matter's `package.json` which will tell Browserify to run the `babelify` transform on matter's files so users don't have to worry about adding it to their `.babelrc`.

``` json
"browserify": {
    "transform": [
      "babelify"
    ]
  }
```

The second is that in order to parse JSX Babel needs to be given a pragma.  I can specify a top-level pragma in my `.babelrc` but only one, and while matter uses the variable name `element` other libs may use `dom`, etc.  I've mitigated this by naming the pragma at the top of the files being imported so Babel knows what pragma to use for that file and I don't have to specify it in my `.babelrc`.

``` js
/** @jsx element */
```

Both of these issues can be solved another way, which is to compile matter's files on publish and have the `package.json` point to those built files as an entry point.  I first saw @dominicbarnes do this with https://github.com/dominicbarnes/deku-forms and I copied the process to one of my own modules and it worked out well.  I think I saw a comment a few days ago by someone somewhere saying it's a good practice to compile files before publishing them to `npm`?  I'm still learning so I don't really know.

In any case I chose this route so I wouldn't have to mess with the build process.  Thanks again for getting all those modules published!
